### PR TITLE
Vim Script の修正

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -156,17 +156,17 @@ let g:SignatureMap = { 'Leader' : "m", 'PlaceNextMark' : "", 'ToggleMarkAtLine' 
 let g:SignatureIncludeMarks = "abcdefghijklmnopqrstuvwxyz"
 
 " ファイル、ディレクトリのコピー
-command! CopyRelativeFileName :call s:CopyRelativeFileName()
+command! CopyRelativePath :call s:CopyRelativeFileName()
 function! s:CopyRelativeFileName()
   let @* = expand('%')
 endfunction
 
-command! CopyAbsoluteFileName :call s:CopyAbsoluteFileName()
+command! CopyAbsolutePath :call s:CopyAbsoluteFileName()
 function! s:CopyAbsoluteFileName()
   let @* = expand('%:p')
 endfunction
 
-command! CopyDirName :call s:CopyDirName()
+command! CopyDir :call s:CopyDirName()
 function! s:CopyDirName()
   let @* = expand('%:p:h')
 endfunction

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -156,18 +156,18 @@ let g:SignatureMap = { 'Leader' : "m", 'PlaceNextMark' : "", 'ToggleMarkAtLine' 
 let g:SignatureIncludeMarks = "abcdefghijklmnopqrstuvwxyz"
 
 " ファイル、ディレクトリのコピー
-command! CopyRelativePath :call s:CopyRelativeFileName()
-function! s:CopyRelativeFileName()
+command! CopyRelativePath :call s:CopyRelativePath()
+function! s:CopyRelativePath()
   let @* = expand('%')
 endfunction
 
-command! CopyAbsolutePath :call s:CopyAbsoluteFileName()
-function! s:CopyAbsoluteFileName()
+command! CopyAbsolutePath :call s:CopyAbsolutePath()
+function! s:CopyAbsolutePath()
   let @* = expand('%:p')
 endfunction
 
-command! CopyDir :call s:CopyDirName()
-function! s:CopyDirName()
+command! CopyDir :call s:CopyDir()
+function! s:CopyDir()
   let @* = expand('%:p:h')
 endfunction
 

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -168,6 +168,6 @@ endfunction
 
 command! CopyDirName :call s:CopyDirName()
 function! s:CopyDirName()
-  let @* = expand('%:h')
+  let @* = expand('%:p:h')
 endfunction
 


### PR DESCRIPTION
- fix: :bug: #5 Vim Script の修正
- refactor: :recycle: 関数名の修正
- refactor: :recycle: 関数名の修正 CopyRelativeFileName -> CopyRelativePath CopyAbsoluteFileName -> CopyAbsolutePath CopyDirName -> CopyDir
